### PR TITLE
Fixing type error for interceptor list

### DIFF
--- a/lib/src/code_generators/swagger_requests_generator.dart
+++ b/lib/src/code_generators/swagger_requests_generator.dart
@@ -113,7 +113,7 @@ class SwaggerRequestsGenerator extends SwaggerGeneratorBase {
         ..optionalParameters.add(Parameter(
           (p) => p
             ..named = true
-            ..type = Reference('Iterable<dynamic>?')
+            ..type = Reference('List<Interceptor>?')
             ..name = 'interceptors',
         ))
         ..body = Code(body),


### PR DESCRIPTION
Chopper requires a List<Interceptor> for the instance of ChopperClient. The given type here was Iterable<dynamic>. I changed the type in the initializer to fit the requirements of chopper.